### PR TITLE
Add sink abstraction (#1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,26 +4,30 @@ DEP ?= `which dep`
 CROWD_ENTRYPOINT ?= `pwd`/src/crowd.go
 CROWD ?= `pwd`/bin/crowd
 
+.PHONY: help
+help: ## Lists the available commands
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+
 .PHONY: build
-build:
+build: ## Builds the app main binary
 	@$(GO) build -o $(CROWD) $(CROWD_ENTRYPOINT)
 
 .PHONY: install
-install:
+install: ## Installs app dependencies
 	@$(DEP) ensure
 
 .PHONY: run
-run:
+run: ## Runs the app
 	@$(CROWD)
 
 .PHONY: test
-test:
+test: ## Runs tests
 	@$(GO) test -v ./...
 
 .PHONY: compose
-compose:
+compose: ## Runs docker compose dependencies
 	@$(DOCKER_COMPOSE) up
 
 .PHONY: decompose
-decompose:
+decompose: ## Stops docker compose dependencies
 	@$(DOCKER_COMPOSE) down

--- a/README.md
+++ b/README.md
@@ -80,9 +80,11 @@ It is important to notice that, for most projects, you could probably rewrite yo
 
 ## Commands
 
-* `make install` - install all the go dependencies with dep.
-* `make build` - build the `crowd` executable.
-* `make run` - start a crowd server with default values.
-* `make test` - run tests
-* `make compose` - start docker compose with dependencies (sqs local, ...).
-* `make decompose` - stop docker compose containers.
+```
+make help                           Lists the available commands
+make install                        Installs app dependencies
+make run                            Runs the app
+make test                           Runs tests
+make compose                        Runs docker compose dependencies
+make decompose                      Stops docker compose dependencies
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,0 @@
-version: "3.7"
-
-services:
-  sqs:
-    image: vsouza/sqs-local
-    ports:
-      - "9324:9324"

--- a/pkg/sink/sqs.go
+++ b/pkg/sink/sqs.go
@@ -1,0 +1,28 @@
+package sink
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+)
+
+type SQS struct {
+	Client sqsiface.SQSAPI
+	Url    string
+}
+
+func NewSQS(url string) SQS {
+	queue := sqs.New(session.Must(session.NewSession(&aws.Config{})))
+
+	return SQS{queue, url}
+}
+
+func (s SQS) Push(payload []byte) error {
+	_, err := s.Client.SendMessage(&sqs.SendMessageInput{
+		MessageBody: aws.String(string(payload)),
+		QueueUrl:    aws.String(s.Url),
+	})
+
+	return err
+}

--- a/pkg/sink/sqs_test.go
+++ b/pkg/sink/sqs_test.go
@@ -1,0 +1,37 @@
+package sink
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
+)
+
+type mockSQS struct {
+	sqsiface.SQSAPI
+	Counter int
+	Resp    sqs.SendMessageOutput
+}
+
+func (m *mockSQS) SendMessage(*sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
+	m.Counter++
+
+	return &m.Resp, nil
+}
+
+func TestSQS(t *testing.T) {
+	mock := mockSQS{Counter: 0}
+
+	q := &SQS{
+		Client: &mock,
+		Url:    "http://localhost:9324/sqs/123",
+	}
+
+	q.Push([]byte("test"))
+	q.Push([]byte("test"))
+	q.Push([]byte("test"))
+
+	if mock.Counter != 3 {
+		t.Errorf("SQS did not receive push")
+	}
+}

--- a/pkg/sink/sqs_test.go
+++ b/pkg/sink/sqs_test.go
@@ -22,14 +22,14 @@ func (m *mockSQS) SendMessage(*sqs.SendMessageInput) (*sqs.SendMessageOutput, er
 func TestSQS(t *testing.T) {
 	mock := mockSQS{Counter: 0}
 
-	q := &SQS{
+	s := &SQS{
 		Client: &mock,
 		Url:    "http://localhost:9324/sqs/123",
 	}
 
-	q.Push([]byte("test"))
-	q.Push([]byte("test"))
-	q.Push([]byte("test"))
+	s.Push([]byte("test"))
+	s.Push([]byte("test"))
+	s.Push([]byte("test"))
 
 	if mock.Counter != 3 {
 		t.Errorf("SQS did not receive push")

--- a/pkg/sink/void.go
+++ b/pkg/sink/void.go
@@ -1,0 +1,19 @@
+package sink
+
+import "fmt"
+
+type Void struct {
+	Debug bool
+}
+
+func NewVoid() Void {
+	return Void{Debug: true}
+}
+
+func (v Void) Push(payload []byte) error {
+	if v.Debug {
+		fmt.Println("debug: ", string(payload))
+	}
+
+	return nil
+}

--- a/src/crowd.go
+++ b/src/crowd.go
@@ -1,37 +1,47 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
 
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/14-bits/crowd/pkg/sink"
 	"github.com/julienschmidt/httprouter"
 )
 
 var port int
 var endpoint string
-var queue string
+var sinkType string
+var sinkUrl string
 
 func init() {
 	flag.IntVar(&port, "port", 2104, "HTTP Server Port")
 	flag.StringVar(&endpoint, "endpoint", "/api/foo", "HTTP path to receive POST requests")
-	flag.StringVar(&queue, "queue", "https://sqs.eu-central-1.amazonaws.com/21042018/foo", "URL for the SQS queue")
+	flag.StringVar(&sinkType, "sink-type", "void", "Sink adapter, e.g.: void, sqs, redis...")
+	flag.StringVar(&sinkUrl, "sink-url", "void", "Connection String/URL for the the sink")
 	flag.Parse()
 }
 
-type Queue struct {
-	Client sqsiface.SQSAPI
-	URL    string
+type Sink interface {
+	Push(payload []byte) error
 }
+
 type Crowd struct {
-	q Queue
+	S Sink
+}
+
+func selectSink(name string, url string) (Sink, error) {
+	switch name {
+	case "sqs":
+		return sink.NewSQS(url), nil
+	case "void":
+		return sink.NewVoid(), nil
+	default:
+		return nil, errors.New("sink is not supported")
+	}
 }
 
 func (c *Crowd) Handle(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
@@ -43,10 +53,7 @@ func (c *Crowd) Handle(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 		return
 	}
 
-	_, err = c.q.Client.SendMessage(&sqs.SendMessageInput{
-		MessageBody: aws.String(string(body)),
-		QueueUrl:    aws.String(queue),
-	})
+	err = c.S.Push(body)
 
 	if err != nil {
 		http.Error(w, err.Error(), 500)
@@ -55,15 +62,18 @@ func (c *Crowd) Handle(w http.ResponseWriter, r *http.Request, _ httprouter.Para
 }
 
 func main() {
-	c := sqs.New(session.Must(session.NewSession(&aws.Config{})))
-	q := Queue{Client: c}
-	crowd := Crowd{q: q}
+	s, err := selectSink(sinkType, sinkUrl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	crowd := Crowd{S: s}
 
 	router := httprouter.New()
 	router.POST(endpoint, crowd.Handle)
 
 	address := fmt.Sprintf(":%d", port)
-	log.Println("crowd is running at", address, "with", endpoint, "-->", queue)
+	log.Println("crowd is running at", address, "with", endpoint, "-->", sinkType)
 
 	http.ListenAndServe(address, router)
 }

--- a/src/crowd_test.go
+++ b/src/crowd_test.go
@@ -7,29 +7,18 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/service/sqs"
-	"github.com/aws/aws-sdk-go/service/sqs/sqsiface"
-
+	"github.com/14-bits/crowd/pkg/sink"
 	"github.com/julienschmidt/httprouter"
 )
 
-type mockSQS struct {
-	sqsiface.SQSAPI
-	Resp sqs.SendMessageOutput
-}
-
-func (m mockSQS) SendMessage(*sqs.SendMessageInput) (*sqs.SendMessageOutput, error) {
-	return &m.Resp, nil
-}
-
 func TestCrowd(t *testing.T) {
-	q := Queue{
-		Client: mockSQS{},
-		URL:    "http://localhost:9324",
+	c := Crowd{
+		S: sink.NewVoid(),
 	}
-	crowd := Crowd{q: q}
+
 	router := httprouter.New()
-	router.POST("/api/foo", crowd.Handle)
+	router.POST("/api/foo", c.Handle)
+
 	data := url.Values{}
 	data.Add("foo", "bar")
 


### PR DESCRIPTION
Having a "Sink" interface and package facilitates the future develpoment
of new Adapters/Sinks, so that we can implement Redis/RabbitMQ or even
Kinesis/Kafka.

The abstraction helps to create unit tests mocking sink side-effects.

There is also in this commit, a new sink, for testing purposes: Void. As
the name implies it does nothing with the message, but there is an
option to print it for debugging purposes.
